### PR TITLE
Removed placeholder from rest docs, changed event logger path, java 16 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.log.*
 .DS_Store
 HELP.md
 target/

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,35 @@
 
 	<build>
 		<plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <!-- <source>16</source> -->
+                    <!-- <target>16</target> -->
+                    <fork>true</fork>
+                    <compilerArgs>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.16</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -9,12 +9,6 @@
 :operation-http-response-title: Example response
 :current-version: 1.1
 
-[source,json]
-----
-{"id":123,"itemName":"item","goodType":666,"quantity":89,"buyPrice":467.0,"sellPrice":555.0,"location":"Montreal, Quebec","billOfMaterial":null}
-----
-
-
 [[overview]]
 = Overview
 

--- a/src/main/java/ca/serum390/godzilla/api/handlers/ProductionManagerHandler.java
+++ b/src/main/java/ca/serum390/godzilla/api/handlers/ProductionManagerHandler.java
@@ -260,12 +260,10 @@ public class ProductionManagerHandler {
         logger = Logger.getLogger("EventLog");
         FileHandler fh;
         try {
-            File dest = new File("src/main/java/ca/serum390/godzilla/util/Events/eventsLog.log");
-            fh = new FileHandler(dest.getAbsolutePath());
+            fh = new FileHandler(new File("eventsLog.log").getAbsolutePath());
             logger.addHandler(fh);
             SimpleFormatter formatter = new SimpleFormatter();
             fh.setFormatter(formatter);
-
         } catch (SecurityException | IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
# Description

- Removed some placeholder text from the spring rest docs
- Changed the event logger to no longer log to `src` dir
- Added compiler args to get Lombok working with Java 16

## How to Test

Run the regular tests
