### PR TITLE
Added Custom Toolbar to All (Other) DataGrids on Site

### DIFF
--- a/src/main/app/src/components/Accounting.js
+++ b/src/main/app/src/components/Accounting.js
@@ -1,10 +1,7 @@
 import React from "react";
 import { makeStyles } from '@material-ui/core';
-
-import {
-  DataGrid, GridToolbarContainer, GridToolbarExport, GridColumnsToolbarButton,
-  GridFilterToolbarButton
-} from '@material-ui/data-grid';
+import {DataGrid} from '@material-ui/data-grid';
+import CustomToolbar from './tables/CustomToolbar';
 import { SpinBeforeLoading } from './inventory/Inventory';
 
 
@@ -62,15 +59,6 @@ const purchaseRows = [
 
 ];
 
-function CustomToolbar() {
-  return (
-    <GridToolbarContainer>
-      <GridColumnsToolbarButton />
-      <GridFilterToolbarButton />
-      <GridToolbarExport />
-    </GridToolbarContainer>
-  );
-}
 const LoadedView = () => {
 
   return (

--- a/src/main/app/src/components/Production.js
+++ b/src/main/app/src/components/Production.js
@@ -1,5 +1,6 @@
-import { Button, makeStyles, TextField } from '@material-ui/core';
+import { Button, makeStyles} from '@material-ui/core';
 import { DataGrid } from '@material-ui/data-grid';
+import CustomToolbar from './tables/CustomToolbar';
 import React, { useState } from 'react';
 import { SpinBeforeLoading } from './inventory/Inventory';
 
@@ -106,19 +107,17 @@ const LoadedView = ({ classes, materialRows, productRows }) => {
       <div style={{ height: 720, width: '45%', float: 'left', display: 'table'}}>
         <div style={{width: '100%', display: 'table-row' }}>
           <h2 style={{ float: 'left' }}>Materials</h2>
-          <TextField id="filled-basic" label="Search" variant="filled" style={{ float: 'right' }} />
         </div>
         <div style={{ height: '100%', width: '100%', display: 'table-row' }}>
-          <DataGrid rows={materialRows} columns={materialColumns} pageSize={9} />
+          <DataGrid rows={materialRows} columns={materialColumns} pageSize={9} components={{ Toolbar: CustomToolbar}} />
         </div>
       </div>
       <div style={{ height: 720, width: '50%', float: 'right', display: 'table' }}>
         <div style={{width: '100%', display: 'table-row' }}>
           <h2 style={{ float: 'left' }}>Products</h2>
-          <TextField id="filled-basic" label="Search" variant="filled" style={{ float: 'right' }} />
         </div>
         <div style={{ height: '100%', width: '100%', display: 'table-row' }}>
-          <DataGrid rows={productRows} columns={productColumns} pageSize={9} />
+          <DataGrid rows={productRows} columns={productColumns} pageSize={9} components={{ Toolbar: CustomToolbar}} />
         </div>
       </div>
     </div>

--- a/src/main/app/src/components/Purchasing.js
+++ b/src/main/app/src/components/Purchasing.js
@@ -1,5 +1,6 @@
 import { Button, makeStyles } from '@material-ui/core';
 import { DataGrid } from '@material-ui/data-grid';
+import CustomToolbar from './tables/CustomToolbar';
 import React, { useState } from 'react';
 import { SpinBeforeLoading } from './inventory/Inventory';
 import VendorDetailsForm from "../Forms/VendorDetailsForm";
@@ -164,7 +165,7 @@ const FilledVendorView = (props) => {
     })));
 
   return (
-    <DataGrid rows={contacts} columns={vendorColumns} pageSize={9} />
+    <DataGrid rows={contacts} columns={vendorColumns} pageSize={9} components={{ Toolbar: CustomToolbar}}/>
   );
 };
 
@@ -183,7 +184,7 @@ const FilledOrderView = ({ orders, orderColumns, inventory }) => {
     })));
 
   return (
-    <DataGrid rows={purchases} columns={orderColumns} pageSize={9} />
+    <DataGrid rows={purchases} columns={orderColumns} pageSize={9} components={{ Toolbar: CustomToolbar}}/>
   );
 };
 

--- a/src/main/app/src/components/Sales.js
+++ b/src/main/app/src/components/Sales.js
@@ -1,4 +1,5 @@
 import { DataGrid } from "@material-ui/data-grid";
+import CustomToolbar from './tables/CustomToolbar';
 import { useState } from 'react';
 import { makeStyles } from '@material-ui/core';
 import { SpinBeforeLoading } from "./inventory/Inventory";
@@ -6,8 +7,6 @@ import CustomerForm from "../Forms/CustomerForm";
 import NewSalesOrderForm from "../Forms/NewSalesOrderForm";
 import axios from "axios";
 import Button from "@material-ui/core/Button";
-
-
 
 const cols = [
   { field: 'id', headerName: 'ID', width: 70 },
@@ -124,6 +123,7 @@ const SalesGrid = ({ className, columns, rows, onRowClick }) => {
             columns={columns}
             rows={customerRows}
             onRowClick={onRowClick}
+            components={{ Toolbar: CustomToolbar}}
           />
         </div>
       </div>
@@ -209,6 +209,7 @@ const FilledSalesView = ({ salesOrders, classes }) => {
       rows={orders}
       columns={salesColumns}
       pageSize={9}
+      components={{ Toolbar: CustomToolbar}}
     />
   );
 };

--- a/src/main/app/src/components/inventory/Inventory.js
+++ b/src/main/app/src/components/inventory/Inventory.js
@@ -4,6 +4,7 @@ import AppLogo from '../../misc/logo.svg';
 import '../../misc/React-Spinner.css';
 import { spinnyBoi } from '../About';
 import { DataGrid } from "@material-ui/data-grid";
+import CustomToolbar from '../tables/CustomToolbar';
 import InventoryForm from "../../Forms/InventoryForm";
 import axios from "axios";
 import Button from "@material-ui/core/Button";
@@ -138,7 +139,7 @@ const FilledInventoryView = ({ inventoryItems, classes }) => {
     })));
 
   return (
-    <DataGrid rows={items} columns={inventoryCols} pageSize={9} />
+    <DataGrid rows={items} columns={inventoryCols} pageSize={9} components={{ Toolbar: CustomToolbar}}/>
   );
 };
 

--- a/src/main/app/src/components/tables/CustomToolbar.js
+++ b/src/main/app/src/components/tables/CustomToolbar.js
@@ -1,0 +1,16 @@
+import {
+    GridToolbarContainer, GridToolbarExport, GridColumnsToolbarButton,
+    GridFilterToolbarButton
+  } from '@material-ui/data-grid';
+
+function CustomToolbar() {
+    return (
+      <GridToolbarContainer>
+        <GridColumnsToolbarButton />
+        <GridFilterToolbarButton />
+        <GridToolbarExport />
+      </GridToolbarContainer>
+    );
+  }
+
+export default CustomToolbar;


### PR DESCRIPTION
#178 

Changes:
- Custom Toolbar is now it's own separate component
- Added Custom Toolbar to all datagrids on site

Notes:
- Toolbar can show/hide columns, filter table contents, and export data to .csv
- Exported data works with filters
