### PR TITLE
Fixed Backspace Crashing Forms Opened From DataGrids

### DIFF
--- a/src/main/app/src/Forms/CustomerForm.js
+++ b/src/main/app/src/Forms/CustomerForm.js
@@ -55,6 +55,7 @@ function ProvinceOptions({province, setProvince, defaultValue}) {
           value={province}
           defaultValue={defaultValue}
           onChange={handleChange}
+          onKeyDown={(e) => e.stopPropagation()}
         >
           <MenuItem value="">
             <em>None</em>
@@ -104,6 +105,7 @@ function PhoneNumberInput({contact, setContact}) {
           name="textmask"
           id="formatted-text-mask-input"
           inputComponent={TextMaskCustom}
+          onKeyDown={(e) => e.stopPropagation()}
         />
       </FormControl>
     </div>
@@ -121,6 +123,7 @@ function TextMaskCustom(props) {
       }}
       mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
       placeholderChar={'\u2000'}
+      onKeyDown={(e) => e.stopPropagation()}
       showMask
     />
   );
@@ -182,6 +185,7 @@ export default function CustomerForm(props) {
             type="string"
             defaultValue={vendor.companyName}
             onChange={(event) => setCompanyName(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <TextField
@@ -192,6 +196,7 @@ export default function CustomerForm(props) {
             type="string"
             defaultValue={vendor.contactName}
             onChange={(event) => setContactName(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <TextField
@@ -202,6 +207,7 @@ export default function CustomerForm(props) {
             type="string"
             defaultValue={props.splitAddress}
             onChange={(event) => setAddress(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <Grid container spacing={2}>
@@ -213,7 +219,8 @@ export default function CustomerForm(props) {
                 label="City"
                 type="text"
                 defaultValue={props.splitCity}
-                onChange={(event) => setCity(event.target.value)} 
+                onChange={(event) => setCity(event.target.value)}
+                onKeyDown={(e) => e.stopPropagation()} 
               />
             </Grid>
             <Grid item md={3}>
@@ -226,6 +233,7 @@ export default function CustomerForm(props) {
                 type="text" 
                 defaultValue={props.splitPostal}
                 onChange={(event) => setPostal(event.target.value)} 
+                onKeyDown={(e) => e.stopPropagation()}
               />
             </Grid>
             <Grid item md={3}>

--- a/src/main/app/src/Forms/InventoryForm.js
+++ b/src/main/app/src/Forms/InventoryForm.js
@@ -63,6 +63,7 @@ export default function InventoryForm(props) {
             type="string"
             defaultValue={item.itemName}
             onChange={(event) => setItemName(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <TextField
@@ -73,6 +74,7 @@ export default function InventoryForm(props) {
             type="string"
             defaultValue={item.location}
             onChange={(event) => setLocation(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <TextField
@@ -83,6 +85,7 @@ export default function InventoryForm(props) {
             type="number"
             defaultValue={item.quantity}
             onChange={(event) => setQuantity(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <TextField
@@ -94,6 +97,7 @@ export default function InventoryForm(props) {
             step={0.5}
             defaultValue={item.sellPrice}
             onChange={(event) => setSellPrice(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <TextField
@@ -105,6 +109,7 @@ export default function InventoryForm(props) {
             step={0.5}
             defaultValue={item.buyPrice}
             onChange={(event) => setBuyPrice(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <TextField
@@ -113,6 +118,7 @@ export default function InventoryForm(props) {
             id="goodType"
             label="Good Type"
             onChange={(event) => setGoodType(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
             type="number"
             defaultValue={item.goodType}

--- a/src/main/app/src/Forms/NewProductionForm.js
+++ b/src/main/app/src/Forms/NewProductionForm.js
@@ -69,6 +69,7 @@ export default function NewProductionForm(props) {
             label="Order #"
             type="string"
             onChange={(event) => setOrderID(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <TextField
@@ -78,6 +79,7 @@ export default function NewProductionForm(props) {
             label="Production Date"
             type="date"
             onChange={(event) => setProductionDate(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
         </DialogContent>

--- a/src/main/app/src/Forms/NewPurchaseOrderForm.js
+++ b/src/main/app/src/Forms/NewPurchaseOrderForm.js
@@ -167,6 +167,7 @@ export default function NewPurchaseOrderForm(props) {
               type="date"
               defaultValue={today}
               onChange={(event) => setCreatedDate(event.target.value)}
+              onKeyDown={(e) => e.stopPropagation()}
               fullWidth
             />
             <TextField
@@ -177,6 +178,7 @@ export default function NewPurchaseOrderForm(props) {
               type="date"
               defaultValue={tomorrow}
               onChange={(event) => setDueDate(event.target.value)}
+              onKeyDown={(e) => e.stopPropagation()}
               fullWidth
             />
             <TextField
@@ -187,6 +189,7 @@ export default function NewPurchaseOrderForm(props) {
               type="string"
               defaultValue="Montreal"
               onChange={(event) => setDeliveryLocation(event.target.value)}
+              onKeyDown={(e) => e.stopPropagation()}
               fullWidth
             />
             <FormControl variant="outlined" >
@@ -225,6 +228,7 @@ export default function NewPurchaseOrderForm(props) {
               type="number"
               defaultValue="0"
               variant="outlined"
+              onKeyDown={(e) => e.stopPropagation()}
             />
           </div>
 

--- a/src/main/app/src/Forms/NewSalesOrderForm.js
+++ b/src/main/app/src/Forms/NewSalesOrderForm.js
@@ -61,6 +61,7 @@ export default function NewSalesOrderForm(props) {
             type="date"
             defaultValue={sales.createdDate}
             onChange={(event) => setCreatedDate(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             InputLabelProps={{
               shrink: true,
             }}
@@ -74,6 +75,7 @@ export default function NewSalesOrderForm(props) {
             type="date"
             defaultValue={sales.dueDate}
             onChange={(event) => setDueDate(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             InputLabelProps={{
               shrink: true,
             }}
@@ -87,6 +89,7 @@ export default function NewSalesOrderForm(props) {
             type="string"
             defaultValue={sales.deliveryLocation}
             onChange={(event) => setDeliveryLocation(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             InputLabelProps={{
               shrink: true,
             }}
@@ -100,6 +103,7 @@ export default function NewSalesOrderForm(props) {
             type="string"
             defaultValue={sales.orderType}
             onChange={(event) => setOrderType(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             InputLabelProps={{
               shrink: true,
             }}
@@ -113,6 +117,7 @@ export default function NewSalesOrderForm(props) {
             type="String"
             defaultValue={sales.status}
             onChange={(event) => setStatus(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             InputLabelProps={{
               shrink: true,
             }}

--- a/src/main/app/src/Forms/PhoneInput.js
+++ b/src/main/app/src/Forms/PhoneInput.js
@@ -43,6 +43,7 @@ function PhoneInput() {
                 onChange={handleChange}
                 name="textmask"
                 inputComponent={TextMaskCustom}
+                onKeyDown={(e) => e.stopPropagation()}
             />
         </div >
     );

--- a/src/main/app/src/Forms/QualityForm.js
+++ b/src/main/app/src/Forms/QualityForm.js
@@ -74,6 +74,7 @@ export default function QualityForm(props) {
             max={3}
             valueLabelDisplay="auto"
             marks={marks}
+            onKeyDown={(e) => e.stopPropagation()}
           />
         </DialogContent>
         <DialogActions>

--- a/src/main/app/src/Forms/ShippingForm.js
+++ b/src/main/app/src/Forms/ShippingForm.js
@@ -54,6 +54,7 @@ export default function ShippingForm(props) {
             type="date"
             defaultValue= "2021-01-01"
             onChange={(event) => setShippingDate(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             InputLabelProps={{
               shrink: true,
             }}
@@ -67,6 +68,7 @@ export default function ShippingForm(props) {
             type="number"
             defaultValue={1}
             onChange={(event) => setOrderID(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             InputLabelProps={{
               shrink: true,
             }}
@@ -76,7 +78,8 @@ export default function ShippingForm(props) {
 
           <InputLabel id="label" shrink={true}>Shipping Method</InputLabel>
           <Select labelId="label" id="select" value={shippingMethod}
-                  onChange={(event) => setShippingMethod(event.target.value)}>
+              onKeyDown={(e) => e.stopPropagation()}
+              onChange={(event) => setShippingMethod(event.target.value)}>
             <MenuItem value="air">Air</MenuItem>
             <MenuItem value="car">Car</MenuItem>
             <MenuItem value="ferry">Ferry</MenuItem>

--- a/src/main/app/src/Forms/UserForm.js
+++ b/src/main/app/src/Forms/UserForm.js
@@ -36,6 +36,7 @@ export default function UserForm(props) {
             label="User Name"
             type="string"
             defaultValue={props.userName}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <TextField
@@ -45,6 +46,7 @@ export default function UserForm(props) {
             label="Password"
             type="string"
             defaultValue={props.userPassword}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
          <TextField
@@ -54,6 +56,7 @@ export default function UserForm(props) {
             label="Role"
             type="string"
             defaultValue={props.userRole}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
 

--- a/src/main/app/src/Forms/VendorDetailsForm.js
+++ b/src/main/app/src/Forms/VendorDetailsForm.js
@@ -55,6 +55,7 @@ function ProvinceOptions({province, setProvince, defaultValue}) {
           value={province}
           defaultValue={defaultValue}
           onChange={handleChange}
+          onKeyDown={(e) => e.stopPropagation()}
         >
           <MenuItem value="">
             <em>None</em>
@@ -104,6 +105,7 @@ function PhoneNumberInput({contact, setContact}) {
           name="textmask"
           id="formatted-text-mask-input"
           inputComponent={TextMaskCustom}
+          onKeyDown={(e) => e.stopPropagation()}
         />
       </FormControl>
     </div>
@@ -122,6 +124,7 @@ function TextMaskCustom(props) {
       mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
       placeholderChar={'\u2000'}
       showMask
+      onKeyDown={(e) => e.stopPropagation()}
     />
   );
 }
@@ -182,6 +185,7 @@ export default function PurchaseOrderForm(props) {
             type="string"
             defaultValue={vendor.companyName}
             onChange={(event) => setCompanyName(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <TextField
@@ -192,6 +196,7 @@ export default function PurchaseOrderForm(props) {
             type="string"
             defaultValue={vendor.contactName}
             onChange={(event) => setContactName(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <TextField
@@ -202,6 +207,7 @@ export default function PurchaseOrderForm(props) {
             type="string"
             defaultValue={props.splitAddress}
             onChange={(event) => setAddress(event.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
             fullWidth
           />
           <Grid container spacing={2}>
@@ -214,6 +220,7 @@ export default function PurchaseOrderForm(props) {
                 type="text"
                 defaultValue={props.splitCity}
                 onChange={(event) => setCity(event.target.value)} 
+                onKeyDown={(e) => e.stopPropagation()}
               />
             </Grid>
             <Grid item md={3}>
@@ -226,6 +233,7 @@ export default function PurchaseOrderForm(props) {
                 type="text" 
                 defaultValue={props.splitPostal}
                 onChange={(event) => setPostal(event.target.value)} 
+                onKeyDown={(e) => e.stopPropagation()}
               />
             </Grid>
             <Grid item md={3}>


### PR DESCRIPTION
NOTE:
- Pressing backspace anywhere (that ISN'T a text field) on a form opened from a datagrid will still crash
- This only includes select boxes
- Datagrids are weird

